### PR TITLE
Corrected typo in timing output to not included 'seconds' after 'sec'

### DIFF
--- a/Users/GetUserList.py
+++ b/Users/GetUserList.py
@@ -167,4 +167,4 @@ print '\n\nTotal Members found: %s' % totalMembers
 totalTimeStop = datetime.datetime.fromtimestamp(time.time())
 totalTimeInSeconds = (totalTimeStop-totalTimeStart).total_seconds()
 timeAsStr = printTimeInHoursMinutesSeconds( totalTimeInSeconds )
-printmessageblock( " Script finished running, it took %s seconds." % ( timeAsStr ) )
+printmessageblock( " Script finished running, it took %s" % ( timeAsStr ) )


### PR DESCRIPTION
Hey Rachel,

I changed the end of the code so that the output will now no longer read "sec seconds". "Seconds" has been removed.

-Case